### PR TITLE
Add capability to force install

### DIFF
--- a/src/duckdb_extensions/extension_importer.py
+++ b/src/duckdb_extensions/extension_importer.py
@@ -12,7 +12,7 @@ except ImportError:
     import importlib.resources as ilr
 
 
-def import_extension(name: str):
+def import_extension(name: str, force_install: bool = False):
     quack_module = importlib.import_module(f"duckdb_extension_{name}")
     module_path = pathlib.Path(str(ilr.files(quack_module)))
 
@@ -21,4 +21,4 @@ def import_extension(name: str):
     extension_dir = module_path / "extensions" / duckdb_version
     extension_file = extension_dir / f"{name}.duckdb_extension"
 
-    duckdb.sql(f"INSTALL '{extension_file}'")
+    duckdb.sql(f"{'FORCE ' if force_install else ''} INSTALL '{extension_file}'")


### PR DESCRIPTION
Bonjour,
Je me permet de proposer une petite évolution, qui permet de forcer l'installation et supprimer ce problème.

```duckdb.duckdb.InvalidInputException: Invalid Input Error: Installing extension 'azure' failed. The extension is already installed but the origin is different.
Currently installed extension is from repository 'http://extensions.duckdb.org', while the extension to be installed is from custom_path '/home/default/.miniforge/envs/monenv/lib/python3.12/site-packages/duckdb_extension_azure/extensions/v1.2.0/azure.duckdb_extension'.
To solve this rerun this command with "FORCE INSTALL"