### PR TITLE
Enable Linux ARM Support

### DIFF
--- a/.github/workflows/publish-arrow-to-pypi.yml
+++ b/.github/workflows/publish-arrow-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_arrow
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_arrow for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_arrow
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_arrow for linux_arm64
+      working-directory: ./extensions/duckdb_extension_arrow
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_arrow for osx_amd64
       working-directory: ./extensions/duckdb_extension_arrow
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-autocomplete-to-pypi.yml
+++ b/.github/workflows/publish-autocomplete-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_autocomplete
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_autocomplete for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_autocomplete
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_autocomplete for linux_arm64
+      working-directory: ./extensions/duckdb_extension_autocomplete
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_autocomplete for osx_amd64
       working-directory: ./extensions/duckdb_extension_autocomplete
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-aws-to-pypi.yml
+++ b/.github/workflows/publish-aws-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_aws
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_aws for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_aws
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_aws for linux_arm64
+      working-directory: ./extensions/duckdb_extension_aws
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_aws for osx_amd64
       working-directory: ./extensions/duckdb_extension_aws
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-azure-to-pypi.yml
+++ b/.github/workflows/publish-azure-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_azure
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_azure for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_azure
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_azure for linux_arm64
+      working-directory: ./extensions/duckdb_extension_azure
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_azure for osx_amd64
       working-directory: ./extensions/duckdb_extension_azure
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-delta-to-pypi.yml
+++ b/.github/workflows/publish-delta-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_delta
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_delta for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_delta
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_delta for linux_arm64
+      working-directory: ./extensions/duckdb_extension_delta
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_delta for osx_amd64
       working-directory: ./extensions/duckdb_extension_delta
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-excel-to-pypi.yml
+++ b/.github/workflows/publish-excel-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_excel
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_excel for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_excel
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_excel for linux_arm64
+      working-directory: ./extensions/duckdb_extension_excel
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_excel for osx_amd64
       working-directory: ./extensions/duckdb_extension_excel
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-fts-to-pypi.yml
+++ b/.github/workflows/publish-fts-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_fts
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_fts for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_fts
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_fts for linux_arm64
+      working-directory: ./extensions/duckdb_extension_fts
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_fts for osx_amd64
       working-directory: ./extensions/duckdb_extension_fts
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-httpfs-to-pypi.yml
+++ b/.github/workflows/publish-httpfs-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_httpfs
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_httpfs for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_httpfs
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_httpfs for linux_arm64
+      working-directory: ./extensions/duckdb_extension_httpfs
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_httpfs for osx_amd64
       working-directory: ./extensions/duckdb_extension_httpfs
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-iceberg-to-pypi.yml
+++ b/.github/workflows/publish-iceberg-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_iceberg
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_iceberg for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_iceberg
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_iceberg for linux_arm64
+      working-directory: ./extensions/duckdb_extension_iceberg
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_iceberg for osx_amd64
       working-directory: ./extensions/duckdb_extension_iceberg
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-inet-to-pypi.yml
+++ b/.github/workflows/publish-inet-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_inet
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_inet for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_inet
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_inet for linux_arm64
+      working-directory: ./extensions/duckdb_extension_inet
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_inet for osx_amd64
       working-directory: ./extensions/duckdb_extension_inet
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-json-to-pypi.yml
+++ b/.github/workflows/publish-json-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_json
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_json for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_json
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_json for linux_arm64
+      working-directory: ./extensions/duckdb_extension_json
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_json for osx_amd64
       working-directory: ./extensions/duckdb_extension_json
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-motherduck-to-pypi.yml
+++ b/.github/workflows/publish-motherduck-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_motherduck
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_motherduck for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_motherduck
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_motherduck for linux_arm64
+      working-directory: ./extensions/duckdb_extension_motherduck
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_motherduck for osx_amd64
       working-directory: ./extensions/duckdb_extension_motherduck
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-mysql-to-pypi.yml
+++ b/.github/workflows/publish-mysql-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_mysql
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_mysql for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_mysql
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_mysql for linux_arm64
+      working-directory: ./extensions/duckdb_extension_mysql
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_mysql for osx_amd64
       working-directory: ./extensions/duckdb_extension_mysql
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-mysql_scanner-to-pypi.yml
+++ b/.github/workflows/publish-mysql_scanner-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_mysql_scanner
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_mysql_scanner for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_mysql_scanner
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_mysql_scanner for linux_arm64
+      working-directory: ./extensions/duckdb_extension_mysql_scanner
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_mysql_scanner for osx_amd64
       working-directory: ./extensions/duckdb_extension_mysql_scanner
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-parquet-to-pypi.yml
+++ b/.github/workflows/publish-parquet-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_parquet
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_parquet for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_parquet
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_parquet for linux_arm64
+      working-directory: ./extensions/duckdb_extension_parquet
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_parquet for osx_amd64
       working-directory: ./extensions/duckdb_extension_parquet
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-postgres-to-pypi.yml
+++ b/.github/workflows/publish-postgres-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_postgres
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_postgres for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_postgres
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_postgres for linux_arm64
+      working-directory: ./extensions/duckdb_extension_postgres
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_postgres for osx_amd64
       working-directory: ./extensions/duckdb_extension_postgres
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-postgres_scanner-to-pypi.yml
+++ b/.github/workflows/publish-postgres_scanner-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_postgres_scanner
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_postgres_scanner for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_postgres_scanner
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_postgres_scanner for linux_arm64
+      working-directory: ./extensions/duckdb_extension_postgres_scanner
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_postgres_scanner for osx_amd64
       working-directory: ./extensions/duckdb_extension_postgres_scanner
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-spatial-to-pypi.yml
+++ b/.github/workflows/publish-spatial-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_spatial
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_spatial for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_spatial
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_spatial for linux_arm64
+      working-directory: ./extensions/duckdb_extension_spatial
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_spatial for osx_amd64
       working-directory: ./extensions/duckdb_extension_spatial
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-sqlite-to-pypi.yml
+++ b/.github/workflows/publish-sqlite-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_sqlite
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_sqlite for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_sqlite
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_sqlite for linux_arm64
+      working-directory: ./extensions/duckdb_extension_sqlite
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_sqlite for osx_amd64
       working-directory: ./extensions/duckdb_extension_sqlite
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-sqlite3-to-pypi.yml
+++ b/.github/workflows/publish-sqlite3-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_sqlite3
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_sqlite3 for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_sqlite3
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_sqlite3 for linux_arm64
+      working-directory: ./extensions/duckdb_extension_sqlite3
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_sqlite3 for osx_amd64
       working-directory: ./extensions/duckdb_extension_sqlite3
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-sqlite_scanner-to-pypi.yml
+++ b/.github/workflows/publish-sqlite_scanner-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_sqlite_scanner
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_sqlite_scanner for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_sqlite_scanner
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_sqlite_scanner for linux_arm64
+      working-directory: ./extensions/duckdb_extension_sqlite_scanner
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_sqlite_scanner for osx_amd64
       working-directory: ./extensions/duckdb_extension_sqlite_scanner
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-tpcds-to-pypi.yml
+++ b/.github/workflows/publish-tpcds-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_tpcds
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_tpcds for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_tpcds
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_tpcds for linux_arm64
+      working-directory: ./extensions/duckdb_extension_tpcds
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_tpcds for osx_amd64
       working-directory: ./extensions/duckdb_extension_tpcds
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-tpch-to-pypi.yml
+++ b/.github/workflows/publish-tpch-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_tpch
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_tpch for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_tpch
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_tpch for linux_arm64
+      working-directory: ./extensions/duckdb_extension_tpch
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_tpch for osx_amd64
       working-directory: ./extensions/duckdb_extension_tpch
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/.github/workflows/publish-vss-to-pypi.yml
+++ b/.github/workflows/publish-vss-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_vss
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_vss for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_vss
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_vss for linux_arm64
+      working-directory: ./extensions/duckdb_extension_vss
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_vss for osx_amd64
       working-directory: ./extensions/duckdb_extension_vss
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pip installable duckdb core extensions so you don't have to leave your python ec
 
 **The architectures supported:**
 - `linux_amd64_gcc4`
+- `linux_arm64`
 - `osx_arm64`
 - `osx_amd64`
 - `windows_amd64`

--- a/templates/duckdb_extension_{@cookiecutter.extension_name@}/publish-{@cookiecutter.extension_name@}-to-pypi.yml
+++ b/templates/duckdb_extension_{@cookiecutter.extension_name@}/publish-{@cookiecutter.extension_name@}-to-pypi.yml
@@ -27,10 +27,10 @@ jobs:
       working-directory: ./extensions/duckdb_extension_{@cookiecutter.extension_name@}
       run: |
         uv tool run hatch build -t wheel linux_amd64_gcc4
-#    - name: build duckdb_extension_{@cookiecutter.extension_name@} for linux_arm64
-#      working-directory: ./extensions/duckdb_extension_{@cookiecutter.extension_name@}
-#      run: |
-#        uv tool run hatch build -t wheel linux_arm64
+    - name: build duckdb_extension_{@cookiecutter.extension_name@} for linux_arm64
+      working-directory: ./extensions/duckdb_extension_{@cookiecutter.extension_name@}
+      run: |
+        uv tool run hatch build -t wheel linux_arm64
     - name: build duckdb_extension_{@cookiecutter.extension_name@} for osx_amd64
       working-directory: ./extensions/duckdb_extension_{@cookiecutter.extension_name@}
       run: |
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - arm-ubuntu-22.04
+          - ubuntu-24.04-arm
           - windows-latest
           - macos-latest
           - macos-13


### PR DESCRIPTION
This PR enables Linux ARM builds by using the ubuntu-24.04-arm runner.

Builds: https://github.com/amadejkastelic/duckdb_extensions/actions