### PR TITLE
Add import_extension to __init__ for import convenience

### DIFF
--- a/src/duckdb_extensions/__init__.py
+++ b/src/duckdb_extensions/__init__.py
@@ -1,0 +1,3 @@
+from .extension_importer import import_extension
+
+__all__ = ["import_extension"]


### PR DESCRIPTION
For slight convenience of clean imports 😉 

I can also change the READMEs if you want.